### PR TITLE
update locate db & hide/show hidden files

### DIFF
--- a/showfiles.fish
+++ b/showfiles.fish
@@ -1,0 +1,7 @@
+function showfiles -d "Reveals and conceals hidden files in Finder"
+  if [ (count $argv) -gt 0 ]
+    defaults write com.apple.finder AppleShowAllFiles $argv
+    killall Finder /System/Library/CoreServices/Finder.app
+  else
+    echo "Input must be YES or NO"
+end

--- a/updatedb.fish
+++ b/updatedb.fish
@@ -1,0 +1,3 @@
+function updatedb -d "Updates 'locate' database"
+  sudo /usr/libexec/locate.updatedb
+end


### PR DESCRIPTION
Added two functions: One to update the 'locate' database so one may conduct command line file searches; and one to reveal and conceal so-called hidden files in the Finder.

Signed-off-by: Daniel Sieradski daniel@self.agency
