### PR TITLE
Update trash.fish

### DIFF
--- a/functions/trash.fish
+++ b/functions/trash.fish
@@ -5,7 +5,7 @@ function trash -d "Move a specified file to the Trash"
       if test -e $item
         set -l item_name (basename $item)
         if test -e "$trash_dir/$item_name"
-          set -l current_time (date "+%H.%M.%S")
+          set -l current_time (date "+%s")
           mv -f "$item" "$trash_dir/$item_name $current_time"
         else
           mv -f "$item" "$trash_dir/"


### PR DESCRIPTION
Change `current_time` to use time since epoch. Ensures a file with a duplicate time never pops up.