### PR TITLE
Updated `pfd` to work with open Info windows

### DIFF
--- a/functions/pfd.fish
+++ b/functions/pfd.fish
@@ -1,6 +1,10 @@
 function pfd -d "Return the path of the frontmost Finder window"
   osascript 2>/dev/null -e '
+    set windowId to 1
     tell application "Finder"
-      return POSIX path of (target of window 1 as alias)
+        repeat while class of window windowId is not Finder window
+            set windowId to windowId + 1
+        end repeat
+        return POSIX path of (target of window windowId as alias)
     end tell'
 end


### PR DESCRIPTION
The previous version of `pfd` doesn't work if the frontmost window is an Info window, and doesn't work at all if there is a floating Info window open anywhere (opened with Cmd + Opt + I).

This version iterates through Finder windows till it finds one of the class `Finder window`, then gets the path of that window's target.