### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/ql.fish
+++ b/functions/ql.fish
@@ -1,6 +1,6 @@
 function ql -d "Quick Look a specified file or directory"
   if [ (count $argv) -gt 0 ]
-    qlmanage >/dev/null ^/dev/null -p $argv &
+    qlmanage >/dev/null 2> /dev/null -p $argv &
   else
     echo "No arguments given"
   end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618