### PR TITLE
Update `manp` for macOS 13 Ventura

### DIFF
--- a/functions/manp.fish
+++ b/functions/manp.fish
@@ -1,6 +1,6 @@
 function manp -d "Open a specified man page in Preview"
   if [ (count $argv) -gt 0 ]
-    man -t $argv | open -f -a Preview
+    mandoc -T pdf (man -w $argv) | open -fa Preview
   else
     echo "No arguments given"
   end


### PR DESCRIPTION
On macOS Ventura, Preview can no longer natively open Postscript files, which breaks the `manp` command.

In this PR, `mandoc` to convert a man page to PDF, which can then be opened with Preview like before.